### PR TITLE
v1.2.0 - Fix skipped tests running on CyServer

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish package to NPM
 on:
   push:
     branches:
-    - master # Push events on master branch
+    - develop # Push events on master branch
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish package to NPM
 on:
   push:
     branches:
-    - develop # Push events on master branch
+    - master # Push events on master branch
 
 jobs:
   publish:

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -60,7 +60,7 @@ const registerZbrPlugin = (on, config) => {
 
   on('after:run', async (results) => {
     if (process.env.ZEBRUNNER_RUN_ID) {
-      return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 60000))
+      return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 30000))
         .then(() => {
           console.log('after:run event timeout is done');
         });

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -7,6 +7,7 @@ const { HttpClient, jsonHeaders } = require('../api-client-axios');
 const { ConfigResolver } = require('../config-resolver');
 const { LogUtil } = require('../log-util');
 const { urls, getRefreshToken } = require('../request-builder');
+const { waitForFileExists } = require('../utils');
 
 const registerZbrPlugin = (on, config) => {
   const ipcConnectionAlias = `zbr-${process.ppid}`;
@@ -60,10 +61,13 @@ const registerZbrPlugin = (on, config) => {
 
   on('after:run', async (results) => {
     if (process.env.ZEBRUNNER_RUN_ID) {
-      return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 30000))
-        .then(() => {
-          console.log('after:run event timeout is done');
-        });
+      return waitForFileExists(`./.${process.env.ZEBRUNNER_RUN_ID}`, 0, 60000, 1000).then(() => {
+        console.log('after:run event timeout is done');
+      });
+      // return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 30000))
+      //   .then(() => {
+      //     console.log('after:run event timeout is done');
+      //   });
     }
 
     return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 1000)).then(async () => {

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -53,9 +53,14 @@ const registerZbrPlugin = (on, config) => {
     console.log('before:run details', details);
   });
 
+  // on('after:spec', (spec, results) => {
+  //   console.log('after:spec', spec);
+  //   console.log('after:spec', results);
+  // });
+
   on('after:run', async (results) => {
     if (process.env.ZEBRUNNER_RUN_ID) {
-      return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 6000))
+      return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 60000))
         .then(() => {
           console.log('after:run event timeout is done');
         });

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -61,13 +61,12 @@ const registerZbrPlugin = (on, config) => {
 
   on('after:run', async (results) => {
     if (process.env.ZEBRUNNER_RUN_ID) {
-      return waitForFileExists(`./.${process.env.ZEBRUNNER_RUN_ID}`, 0, 60000, 1000).then(() => {
-        console.log('after:run event timeout is done');
+      // wait for all finishTestPromises on EVENT_RUN_END
+      // then create a file .${process.env.ZEBRUNNER_RUN_ID} that means Zebrunner reporting is done
+      const timeout = process.env.ZBR_RUN_END_TIMEOUT || 60000;
+      return waitForFileExists(`./.${process.env.ZEBRUNNER_RUN_ID}`, 0, timeout, 1000).then(() => {
+        console.log('ZEBRUNNER_RUN_END');
       });
-      // return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 30000))
-      //   .then(() => {
-      //     console.log('after:run event timeout is done');
-      //   });
     }
 
     return new Promise((resolve) => setTimeout(resolve, process.env.ZBR_RUN_END_TIMEOUT || 1000)).then(async () => {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -144,7 +144,7 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_PENDING: {
-      console.log(`EVENT_TEST_PENDING: ${message.test.title} ${new Date().toLocaleTimeString()}`);
+      // console.log(`EVENT_TEST_PENDING: ${message.test.title} ${new Date().toLocaleTimeString()}`);
       break;
     }
     case EVENT_TEST_PASS: {
@@ -157,8 +157,12 @@ process.on('message', async (message) => {
     }
     case EVENT_TEST_END: {
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        console.log('No started test on EVENT_TEST_END!'); // TODO: maybe do nothing?
-        startTest(message);
+        // Use case when EVENT_TEST_END comes after EVENT_SUITE_END
+        console.log(`Use case when EVENT_TEST_END comes after EVENT_SUITE_END: ${message.test.title}`);
+        // TODO: to remove above log
+        break;
+        // console.log('No started test on EVENT_TEST_END!');
+        // startTest(message);
       }
 
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
@@ -239,11 +243,8 @@ process.on('message', async (message) => {
     }
 
     case EVENT_RUN_END: {
-      console.log('ZEBRUNNER_RUN_END wait for promises');
-      console.log(finishTestPromises);
       await Promise.all(finishTestPromises);
       console.log('ZEBRUNNER_RUN_END');
-      console.log(finishTestPromises);
       break;
     }
     default:

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -124,7 +124,7 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      console.log(`EVENT_TEST_BEGIN: ${message.test.title} ${new Date().toLocaleTimeString()}`);
+      console.log(`EVENT_TEST_BEGIN: ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
         // Use case when EVENT_TEST_BEGIN comes after EVENT_TEST_END for fast tests
         startTest(message);
@@ -164,7 +164,7 @@ process.on('message', async (message) => {
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
-      console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.title} ${new Date().toLocaleTimeString()}`);
+      console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { v4: uuidv4 } = require('uuid');
 const ZebrunnerApiClient = require('./zebr-api-client');
 const { workerEvents } = require('./constants');
-const { getFailedScreenshot } = require('./utils');
+const { getFailedScreenshot, writeToFile } = require('./utils');
 const { ConfigResolver } = require('./config-resolver');
 const { LogUtil } = require('./log-util');
 
@@ -244,6 +244,11 @@ process.on('message', async (message) => {
 
     case EVENT_RUN_END: {
       await Promise.all(finishTestPromises);
+
+      if (process.env.ZEBRUNNER_RUN_ID) {
+        console.log('Save finish run state to file');
+        writeToFile('./', `.${process.env.ZEBRUNNER_RUN_ID}`, `ZEBRUNNER_RUN_END: ${process.env.ZEBRUNNER_RUN_ID}`);
+      }
       console.log('ZEBRUNNER_RUN_END');
       break;
     }

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -107,9 +107,6 @@ process.on('message', async (message) => {
           .then(() => {
             zebrunnerApiClient.startTestSession(message.test, sessionId)
               .then(() => {
-                // IMPORTANT: don't delete as it is used by CyServer to start video recording
-                console.log('Start capturing artifacts sessionId', sessionId);
-
                 const parsedTestLogs = message.test.body
                   .split('\n')
                   .map((el) => el.trim())

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -124,7 +124,7 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      console.log(`EVENT_TEST_BEGIN: ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
+      // console.log(`EVENT_TEST_BEGIN: ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
         // Use case when EVENT_TEST_BEGIN comes after EVENT_TEST_END for fast tests
         startTest(message);
@@ -144,7 +144,7 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_PENDING: {
-      // console.log(`EVENT_TEST_PENDING: ${message.test.title} ${new Date().toLocaleTimeString()}`);
+      console.log(`EVENT_TEST_PENDING: ${message.test.title} ${new Date().toLocaleTimeString()}`);
       break;
     }
     case EVENT_TEST_PASS: {
@@ -157,7 +157,7 @@ process.on('message', async (message) => {
     }
     case EVENT_TEST_END: {
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        console.log('No started test on EVENT_TEST_END!');
+        console.log('No started test on EVENT_TEST_END!'); // TODO: maybe do nothing?
         startTest(message);
       }
 
@@ -167,14 +167,11 @@ process.on('message', async (message) => {
       console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
-        console.log('Test is present in startTestPromisesMap');
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
           await Promise.all(artifactsFinishPromises);
 
-          console.log('111');
           const promises = [];
           if (message.test.status.toLowerCase() === 'failed') {
-            console.log('222');
             promises.push(zebrunnerApiClient.sendLogs(message.test, [`Failure message: ${message.test?.err}`], 'ERROR'));
             promises.push(getFailedScreenshot(message.test.screenshotFileBaseName, message.test.retries).then((screenshots) => {
               if (screenshots.length > 0) {
@@ -188,24 +185,19 @@ process.on('message', async (message) => {
               return Promise.resolve();
             }));
           }
-          console.log('333');
           promises.push(zebrunnerApiClient.updateTcmTestCases(message.test, message.test.status.toUpperCase()));
           promises.push(zebrunnerApiClient.finishTestSession(message.test));
           promises.push(zebrunnerApiClient.finishTest(message.test, message.test.status.toUpperCase(), message.test?.err));
 
-          console.log('444');
           return Promise.all(promises).then(() => {
-            console.log('555');
             this.logger.info(path.basename(__filename), `--- TEST ENDED ${message.test.title} ---`);
 
             currentTest = null;
           }).catch((err) => {
-            console.log('666');
             console.log(`Failed to send '${message.test.status.toLowerCase()}' test data, err: `, err);
           });
         }));
       } else {
-        console.log('777');
         console.error(`Test with id ${message.test.uniqueId} not found`);
       }
       break;

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -167,11 +167,14 @@ process.on('message', async (message) => {
       console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
+        console.log('Test is present in startTestPromisesMap');
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
           await Promise.all(artifactsFinishPromises);
 
+          console.log('111');
           const promises = [];
           if (message.test.status.toLowerCase() === 'failed') {
+            console.log('222');
             promises.push(zebrunnerApiClient.sendLogs(message.test, [`Failure message: ${message.test?.err}`], 'ERROR'));
             promises.push(getFailedScreenshot(message.test.screenshotFileBaseName, message.test.retries).then((screenshots) => {
               if (screenshots.length > 0) {
@@ -185,19 +188,24 @@ process.on('message', async (message) => {
               return Promise.resolve();
             }));
           }
+          console.log('333');
           promises.push(zebrunnerApiClient.updateTcmTestCases(message.test, message.test.status.toUpperCase()));
           promises.push(zebrunnerApiClient.finishTestSession(message.test));
           promises.push(zebrunnerApiClient.finishTest(message.test, message.test.status.toUpperCase(), message.test?.err));
 
+          console.log('444');
           return Promise.all(promises).then(() => {
+            console.log('555');
             this.logger.info(path.basename(__filename), `--- TEST ENDED ${message.test.title} ---`);
 
             currentTest = null;
           }).catch((err) => {
+            console.log('666');
             console.log(`Failed to send '${message.test.status.toLowerCase()}' test data, err: `, err);
           });
         }));
       } else {
+        console.log('777');
         console.error(`Test with id ${message.test.uniqueId} not found`);
       }
       break;

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -124,7 +124,11 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      startTest(message);
+      // console.log(`EVENT_TEST_BEGIN: ${message.test.title} ${new Date().toLocaleTimeString()}`);
+      if (!startTestPromisesMap.get(message.test.uniqueId)) {
+        // Use case when EVENT_TEST_BEGIN comes after EVENT_TEST_END for fast tests
+        startTest(message);
+      }
 
       // TODO: investigate 'Tell mocha this is a skipped test so it also shows correctly in Cypress'
       // if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
@@ -152,17 +156,15 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_END: {
-      console.log(`message.test.uniqueId: ${message.test.uniqueId}`); // TODO: debug log
+      if (!startTestPromisesMap.get(message.test.uniqueId)) {
+        console.log('No started test on EVENT_TEST_END!');
+        startTest(message);
+      }
 
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
       console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.title} ${new Date().toLocaleTimeString()}`);
-
-      if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        console.log('No started test on EVENT_TEST_END!');
-        startTest(message);
-      }
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
@@ -193,8 +195,6 @@ process.on('message', async (message) => {
             currentTest = null;
           }).catch((err) => {
             console.log(`Failed to send '${message.test.status.toLowerCase()}' test data, err: `, err);
-          }).finally(() => {
-            startTestPromisesMap.delete(message.test.uniqueId);
           });
         }));
       } else {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -6,6 +6,7 @@ const { workerEvents } = require('./constants');
 const { getFailedScreenshot, writeToFile } = require('./utils');
 const { ConfigResolver } = require('./config-resolver');
 const { LogUtil } = require('./log-util');
+const v8 = require('v8');
 
 const {
   EVENT_RUN_BEGIN,
@@ -125,14 +126,13 @@ process.on('message', async (message) => {
                 });
             }));
 
-        // TODO: investigate 'Tell mocha this is a skipped test so it also shows correctly in Cypress'
+        // TODO: investigate if this block helps do not show Pending tests that will be removed in Zebrunner when they are In Progress
         if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
           if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
-          // TODO: seems outdated, check and remove
-          // console.log('Start test context exchange is fired');
+            // console.log('Start test context exchange is fired');
             startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTestPromise()));
           } else {
-          // console.log('Start test is fired');
+            // console.log('Start test is fired');
             startTestPromisesMap.set(message.test.uniqueId, startTestPromise());
           }
         }
@@ -152,9 +152,13 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_END: {
+      const totalHeapSize = v8.getHeapStatistics().total_available_size;
+      const totalHeapSizeGb = (totalHeapSize / 1024 / 1024 / 1024).toFixed(2);
+      console.log('totalHeapSizeGb: ', totalHeapSizeGb);
+
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
         // Use case when EVENT_TEST_END comes after EVENT_SUITE_END
-        console.log(`Use case when EVENT_TEST_END comes after EVENT_SUITE_END: ${message.test.title}`);
+        console.log(`Use case when EVENT_TEST_END comes after EVENT_SUITE_END: ${message.test.title} ${message.test.status}`);
         // TODO: to remove above log
         break;
       }

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -247,7 +247,11 @@ process.on('message', async (message) => {
     }
 
     case EVENT_RUN_END: {
+      console.log('ZEBRUNNER_RUN_END wait for promises');
+      console.log(finishTestPromises);
+      await Promise.all(finishTestPromises);
       console.log('ZEBRUNNER_RUN_END');
+      console.log(finishTestPromises);
       break;
     }
     default:

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -94,14 +94,11 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      console.log(new Date(Date.now()).toString());
-
       const sessionId = uuidv4();
       testsSessionsMap.set(message.test.uniqueId, sessionId);
 
-      // IMPORTANT: don't delete as it is used by CyServer to truncate video recording
-      console.log(`EVENT_TEST_BEGIN ${sessionId}`);
-      console.log(message.test.title);
+      // IMPORTANT: don't delete as it is used by CyServer to start video recording
+      console.log(`EVENT_TEST_BEGIN ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
 
       currentTest = message.test;
 
@@ -130,10 +127,10 @@ process.on('message', async (message) => {
       if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
         if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
           // TODO: seems outdated, check and remove
-          console.log('Start test context exchange is fired');
+          // console.log('Start test context exchange is fired');
           startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTest()));
         } else {
-          console.log('Start test is fired');
+          // console.log('Start test is fired');
           startTestPromisesMap.set(message.test.uniqueId, startTest());
         }
       }
@@ -155,13 +152,10 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_END: {
-      console.log(new Date(Date.now()).toString());
-
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
-      console.log(`EVENT_TEST_END ${sessionId}`);
-      console.log(message.test.title);
+      console.log(`EVENT_TEST_END ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -95,12 +95,15 @@ process.on('message', async (message) => {
 
     case EVENT_TEST_BEGIN: {
       console.log(new Date(Date.now()).toString());
-      console.log(`EVENT_TEST_BEGIN: ${message.test.title}`);
-
-      currentTest = message.test;
 
       const sessionId = uuidv4();
       testsSessionsMap.set(message.test.uniqueId, sessionId);
+
+      // IMPORTANT: don't delete as it is used by CyServer to truncate video recording
+      console.log(`EVENT_TEST_BEGIN: ${sessionId}`);
+      console.log(message.test.title);
+
+      currentTest = message.test;
 
       const startTest = () => runStartPromise
         .then(() => zebrunnerApiClient.startTest(message.test)
@@ -142,26 +145,23 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_PASS: {
-      console.log(new Date(Date.now()).toString());
-      console.log(`EVENT_TEST_PASS: ${message.test.title}`);
+      // console.log(new Date(Date.now()).toString());
+      // console.log(`EVENT_TEST_PASS: ${message.test.title}`);
       break;
     }
     case EVENT_TEST_FAIL: {
-      console.log(new Date(Date.now()).toString());
-      console.log(`EVENT_TEST_FAIL: ${message.test.title}`);
+      // console.log(new Date(Date.now()).toString());
+      // console.log(`EVENT_TEST_FAIL: ${message.test.title}`);
       break;
     }
     case EVENT_TEST_END: {
       console.log(new Date(Date.now()).toString());
-      console.log(`EVENT_TEST_END: ${message.test.title}`);
 
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
-      console.log(`Session ID: ${sessionId}`);
 
-      if (sessionId) {
-        // IMPORTANT: don't delete as it is used by CyServer to stop video recording
-        console.log('Stop capturing artifacts sessionId', sessionId);
-      }
+      // IMPORTANT: don't delete as it is used by CyServer to stop video recording
+      console.log(`EVENT_TEST_END: ${sessionId}`);
+      console.log(message.test.title);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -170,7 +170,9 @@ process.on('message', async (message) => {
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
       console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
 
-      if (startTestPromisesMap.get(message.test.uniqueId)) {
+      if (message.test.status.toLowerCase() === 'pending') {
+        zebrunnerApiClient.deleteTest(message.test);
+      } else if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
           await Promise.all(artifactsFinishPromises);
 

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -40,6 +40,7 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_RUN_BEGIN: {
+      console.log('ZEBRUNNER_RUN_BEGIN');
       this.logger.info(path.basename(__filename), 'ZEBRUNNER REPORTER STARTED');
       break;
     }
@@ -98,7 +99,7 @@ process.on('message', async (message) => {
       testsSessionsMap.set(message.test.uniqueId, sessionId);
 
       // IMPORTANT: don't delete as it is used by CyServer to start video recording
-      console.log(`EVENT_TEST_BEGIN ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
+      console.log(`ZEBRUNNER_TEST_BEGIN ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
 
       currentTest = message.test;
 
@@ -137,8 +138,8 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_PENDING: {
-      console.log(new Date(Date.now()).toString());
-      console.log(`EVENT_TEST_PENDING: ${message.test.title}`);
+      // console.log(new Date(Date.now()).toString());
+      // console.log(`EVENT_TEST_PENDING: ${message.test.title}`);
       break;
     }
     case EVENT_TEST_PASS: {
@@ -155,7 +156,7 @@ process.on('message', async (message) => {
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
-      console.log(`EVENT_TEST_END ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
+      console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
@@ -230,7 +231,7 @@ process.on('message', async (message) => {
     }
 
     case EVENT_RUN_END: {
-      console.log('ZEBRUNNER REPORTER FINISHED');
+      console.log('ZEBRUNNER_RUN_END');
       break;
     }
     default:

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -152,12 +152,13 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_END: {
-      const totalHeapSize = v8.getHeapStatistics().total_available_size;
-      const totalHeapSizeGb = (totalHeapSize / 1024 / 1024 / 1024).toFixed(2);
+      const stats = v8.getHeapStatistics();
+      const totalHeapSizeGb = (stats.total_heap_size / 1024 / 1024 / 1024).toFixed(2);
       console.log('totalHeapSizeGb: ', totalHeapSizeGb);
+      console.log('full HeapStatistics: ', stats);
 
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        // Use case when EVENT_TEST_END comes after EVENT_SUITE_END
+        // Test skipped by Cypress (cypress-cucumber-preprocessor)
         console.log(`Use case when EVENT_TEST_END comes after EVENT_SUITE_END: ${message.test.title} ${message.test.status}`);
         // TODO: to remove above log
         break;

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -94,16 +94,17 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      console.log('EVENT_TEST_BEGIN');
+      console.log(`EVENT_TEST_BEGIN: ${message.test.title}`);
       console.log(new Date(Date.now()).toString());
-      console.log(message.test.title);
 
       currentTest = message.test;
+
+      const sessionId = uuidv4();
+      testsSessionsMap.set(message.test.uniqueId, sessionId);
+
       const startTest = () => runStartPromise
         .then(() => zebrunnerApiClient.startTest(message.test)
           .then(() => {
-            const sessionId = uuidv4();
-            testsSessionsMap.set(message.test.uniqueId, sessionId);
             zebrunnerApiClient.startTestSession(message.test, sessionId)
               .then(() => {
                 // IMPORTANT: don't delete as it is used by CyServer to start video recording

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -47,8 +47,7 @@ process.on('message', async (message) => {
     }
 
     case EVENT_SUITE_BEGIN: {
-      console.log('EVENT_SUITE_BEGIN');
-      console.log(new Date(Date.now()).toString());
+      console.log(`EVENT_SUITE_BEGIN ${new Date().toLocaleTimeString()}`);
       console.log('message', message);
       // as of now only the first (root) suite will be registered as a new run in zebrunner
       if (message.suite.title && !process.env.ZEBRUNNER_RUN_ID) {
@@ -75,8 +74,7 @@ process.on('message', async (message) => {
     }
 
     case EVENT_SUITE_END: {
-      console.log('EVENT_SUITE_END');
-      console.log(new Date(Date.now()).toString());
+      console.log(`EVENT_SUITE_END ${new Date().toLocaleTimeString()}`);
       console.log('message', message);
       if (message.suite.title) {
         this.logger.info(path.basename(__filename), `suite finished. name: ${message.suite.title}`);
@@ -98,9 +96,6 @@ process.on('message', async (message) => {
     case EVENT_TEST_BEGIN: {
       const sessionId = uuidv4();
       testsSessionsMap.set(message.test.uniqueId, sessionId);
-
-      // IMPORTANT: don't delete as it is used by CyServer to start video recording
-      console.log(`ZEBRUNNER_TEST_BEGIN ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
 
       currentTest = message.test;
 
@@ -139,25 +134,22 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_PENDING: {
-      // console.log(new Date(Date.now()).toString());
-      // console.log(`EVENT_TEST_PENDING: ${message.test.title}`);
+      // console.log(`EVENT_TEST_PENDING: ${message.test.title} ${new Date().toLocaleTimeString()}`);
       break;
     }
     case EVENT_TEST_PASS: {
-      // console.log(new Date(Date.now()).toString());
-      // console.log(`EVENT_TEST_PASS: ${message.test.title}`);
+      // console.log(`EVENT_TEST_PASS: ${message.test.title} ${new Date().toLocaleTimeString()}`);
       break;
     }
     case EVENT_TEST_FAIL: {
-      // console.log(new Date(Date.now()).toString());
-      // console.log(`EVENT_TEST_FAIL: ${message.test.title}`);
+      // console.log(`EVENT_TEST_FAIL: ${message.test.title} ${new Date().toLocaleTimeString()}`);
       break;
     }
     case EVENT_TEST_END: {
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
-      console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.title} ${new Date(Date.now()).toString()}`);
+      console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.title} ${new Date().toLocaleTimeString()}`);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -1,12 +1,12 @@
 const Mocha = require('mocha');
 const path = require('path');
 const { v4: uuidv4 } = require('uuid');
+const v8 = require('v8');
 const ZebrunnerApiClient = require('./zebr-api-client');
 const { workerEvents } = require('./constants');
 const { getFailedScreenshot, writeToFile } = require('./utils');
 const { ConfigResolver } = require('./config-resolver');
 const { LogUtil } = require('./log-util');
-const v8 = require('v8');
 
 const {
   EVENT_RUN_BEGIN,
@@ -97,44 +97,40 @@ process.on('message', async (message) => {
     case EVENT_TEST_BEGIN: {
       // console.log(`EVENT_TEST_BEGIN: ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
 
-      if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        // Use case when EVENT_TEST_BEGIN comes after EVENT_TEST_END for fast tests
+      const sessionId = uuidv4();
+      testsSessionsMap.set(message.test.uniqueId, sessionId);
 
-        const sessionId = uuidv4();
-        testsSessionsMap.set(message.test.uniqueId, sessionId);
+      currentTest = message.test;
 
-        currentTest = message.test;
+      const startTestPromise = () => runStartPromise
+        .then(() => zebrunnerApiClient.startTest(message.test)
+          .then(() => {
+            zebrunnerApiClient.startTestSession(message.test, sessionId)
+              .then(() => {
+                const parsedTestLogs = message.test.body
+                  .split('\n')
+                  .map((el) => el.trim())
+                  .filter((el) => el !== '() => {' && el !== '}' && el);
+                const testLogs = ['TEST BODY: ', ...parsedTestLogs];
 
-        const startTestPromise = () => runStartPromise
-          .then(() => zebrunnerApiClient.startTest(message.test)
-            .then(() => {
-              zebrunnerApiClient.startTestSession(message.test, sessionId)
-                .then(() => {
-                  const parsedTestLogs = message.test.body
-                    .split('\n')
-                    .map((el) => el.trim())
-                    .filter((el) => el !== '() => {' && el !== '}' && el);
-                  const testLogs = ['TEST BODY: ', ...parsedTestLogs];
-
-                  return Promise.all([
-                    zebrunnerApiClient.sendLogs(message.test, testLogs, 'INFO'),
+                return Promise.all([
+                  zebrunnerApiClient.sendLogs(message.test, testLogs, 'INFO'),
                     // TODO: check and fix labeling
-                    zebrunnerApiClient.sendRunLabels(),
-                  ]);
-                }).catch((error) => {
-                  console.log('startTestSession error: ', error);
-                });
-            }));
+                  zebrunnerApiClient.sendRunLabels(),
+                ]);
+              }).catch((error) => {
+                console.log('startTestSession error: ', error);
+              });
+          }));
 
         // TODO: investigate if this block helps do not show Pending tests that will be removed in Zebrunner when they are In Progress
-        if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
-          if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
+      if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
+        if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
             // console.log('Start test context exchange is fired');
-            startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTestPromise()));
-          } else {
+          startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTestPromise()));
+        } else {
             // console.log('Start test is fired');
-            startTestPromisesMap.set(message.test.uniqueId, startTestPromise());
-          }
+          startTestPromisesMap.set(message.test.uniqueId, startTestPromise());
         }
       }
       break;

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -246,10 +246,8 @@ process.on('message', async (message) => {
       await Promise.all(finishTestPromises);
 
       if (process.env.ZEBRUNNER_RUN_ID) {
-        console.log('Save finish run state to file');
         writeToFile('./', `.${process.env.ZEBRUNNER_RUN_ID}`, `ZEBRUNNER_RUN_END: ${process.env.ZEBRUNNER_RUN_ID}`);
       }
-      console.log('ZEBRUNNER_RUN_END');
       break;
     }
     default:

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -124,7 +124,7 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      // console.log(`EVENT_TEST_BEGIN: ${message.test.title} ${new Date().toLocaleTimeString()}`);
+      console.log(`EVENT_TEST_BEGIN: ${message.test.title} ${new Date().toLocaleTimeString()}`);
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
         // Use case when EVENT_TEST_BEGIN comes after EVENT_TEST_END for fast tests
         startTest(message);
@@ -157,7 +157,7 @@ process.on('message', async (message) => {
     }
     case EVENT_TEST_END: {
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        // console.log('No started test on EVENT_TEST_END!');
+        console.log('No started test on EVENT_TEST_END!');
         startTest(message);
       }
 

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -152,10 +152,10 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_END: {
-      const stats = v8.getHeapStatistics();
-      const totalHeapSizeGb = (stats.total_heap_size / 1024 / 1024 / 1024).toFixed(2);
-      console.log('totalHeapSizeGb: ', totalHeapSizeGb);
-      console.log('full HeapStatistics: ', stats);
+      // const stats = v8.getHeapStatistics();
+      // const totalHeapSizeGb = (stats.total_heap_size / 1024 / 1024 / 1024).toFixed(2);
+      // console.log('totalHeapSizeGb: ', totalHeapSizeGb);
+      // console.log('full heapStatistics: ', stats);
 
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
         // Test skipped by Cypress (cypress-cucumber-preprocessor)

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -96,8 +96,7 @@ process.on('message', async (message) => {
     case EVENT_TEST_BEGIN: {
       console.log('EVENT_TEST_BEGIN');
       console.log(new Date(Date.now()).toString());
-      console.log('message', message.test.title);
-      console.debug(message);
+      console.log(message.test.title);
 
       currentTest = message.test;
       const startTest = () => runStartPromise
@@ -142,42 +141,35 @@ process.on('message', async (message) => {
     case EVENT_TEST_PENDING: {
       console.log('EVENT_TEST_PENDING');
       console.log(new Date(Date.now()).toString());
-      console.log('message', message);
+      console.log(message.test.title);
       break;
     }
     case EVENT_TEST_PASS: {
       console.log('EVENT_TEST_PASS');
       console.log(new Date(Date.now()).toString());
-      console.log('message', message);
+      console.log(message.test.title);
       break;
     }
     case EVENT_TEST_FAIL: {
       console.log('EVENT_TEST_FAIL');
       console.log(new Date(Date.now()).toString());
-      console.log('message', message.test.title);
-      console.debug(message);
+      console.log(message.test.title);
       break;
     }
     case EVENT_TEST_END: {
       console.log('EVENT_TEST_END');
       console.log(new Date(Date.now()).toString());
-      console.log('message', message);
+      console.log(message);
 
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
+      console.log(`Session ID: ${sessionId}`);
 
       if (sessionId) {
         // IMPORTANT: don't delete as it is used by CyServer to stop video recording
         console.log('Stop capturing artifacts sessionId', sessionId);
       }
 
-      if (message.test.status.toLowerCase() === 'pending') {
-        // it seems necessary for Cypress 9 and below
-        zebrunnerApiClient.deleteTest(message.test).then(() => {
-          console.log('Pending test deleted');
-        });
-      } else if (startTestPromisesMap.get(message.test.uniqueId)) {
-        console.log(`Test promise(${message.test.uniqueId}): ${startTestPromisesMap.get(message.test.uniqueId)}`);
-
+      if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
           await Promise.all(artifactsFinishPromises);
 

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -94,8 +94,8 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      console.log(`EVENT_TEST_BEGIN: ${message.test.title}`);
       console.log(new Date(Date.now()).toString());
+      console.log(`EVENT_TEST_BEGIN: ${message.test.title}`);
 
       currentTest = message.test;
 
@@ -140,27 +140,23 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_PENDING: {
-      console.log('EVENT_TEST_PENDING');
       console.log(new Date(Date.now()).toString());
-      console.log(message.test.title);
+      console.log(`EVENT_TEST_PENDING: ${message.test.title}`);
       break;
     }
     case EVENT_TEST_PASS: {
-      console.log('EVENT_TEST_PASS');
       console.log(new Date(Date.now()).toString());
-      console.log(message.test.title);
+      console.log(`EVENT_TEST_PASS: ${message.test.title}`);
       break;
     }
     case EVENT_TEST_FAIL: {
-      console.log('EVENT_TEST_FAIL');
       console.log(new Date(Date.now()).toString());
-      console.log(message.test.title);
+      console.log(`EVENT_TEST_FAIL: ${message.test.title}`);
       break;
     }
     case EVENT_TEST_END: {
-      console.log('EVENT_TEST_END');
       console.log(new Date(Date.now()).toString());
-      console.log(message);
+      console.log(`EVENT_TEST_END: ${message.test.title}`);
 
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
       console.log(`Session ID: ${sessionId}`);

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -157,7 +157,7 @@ process.on('message', async (message) => {
     }
     case EVENT_TEST_END: {
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        console.log('No started test on EVENT_TEST_END!');
+        // console.log('No started test on EVENT_TEST_END!');
         startTest(message);
       }
 

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -100,7 +100,7 @@ process.on('message', async (message) => {
       testsSessionsMap.set(message.test.uniqueId, sessionId);
 
       // IMPORTANT: don't delete as it is used by CyServer to truncate video recording
-      console.log(`EVENT_TEST_BEGIN: ${sessionId}`);
+      console.log(`EVENT_TEST_BEGIN ${sessionId}`);
       console.log(message.test.title);
 
       currentTest = message.test;
@@ -160,7 +160,7 @@ process.on('message', async (message) => {
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
-      console.log(`EVENT_TEST_END: ${sessionId}`);
+      console.log(`EVENT_TEST_END ${sessionId}`);
       console.log(message.test.title);
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -96,7 +96,9 @@ process.on('message', async (message) => {
     case EVENT_TEST_BEGIN: {
       console.log('EVENT_TEST_BEGIN');
       console.log(new Date(Date.now()).toString());
-      console.log('message', message);
+      console.log('message', message.test.title);
+      console.debug(message);
+
       currentTest = message.test;
       const startTest = () => runStartPromise
         .then(() => zebrunnerApiClient.startTest(message.test)
@@ -112,10 +114,11 @@ process.on('message', async (message) => {
                   .split('\n')
                   .map((el) => el.trim())
                   .filter((el) => el !== '() => {' && el !== '}' && el);
-                const testLogs = ['ORIGINAL TEST DEFINITION (NOT LIVE LOGS):', ...parsedTestLogs];
+                const testLogs = ['TEST BODY: ', ...parsedTestLogs];
 
                 return Promise.all([
                   zebrunnerApiClient.sendLogs(message.test, testLogs, 'INFO'),
+                  // TODO: check and fix labeling
                   zebrunnerApiClient.sendRunLabels(),
                 ]);
               }).catch((error) => {
@@ -123,15 +126,15 @@ process.on('message', async (message) => {
               });
           }));
 
+          // TODO: investigate 'Tell mocha this is a skipped test so it also shows correctly in Cypress'
       if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
         if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
+          // TODO: seems outdated, check and remove
           console.log('Start test context exchange is fired');
           startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTest()));
-          console.log(`VD variant: ${startTestPromisesMap.get(message.test.uniqueId)}`);
         } else {
           console.log('Start test is fired');
           startTestPromisesMap.set(message.test.uniqueId, startTest());
-          console.log(`SBJr variant: ${startTestPromisesMap.get(message.test.uniqueId)}`);
         }
       }
       break;
@@ -151,14 +154,15 @@ process.on('message', async (message) => {
     case EVENT_TEST_FAIL: {
       console.log('EVENT_TEST_FAIL');
       console.log(new Date(Date.now()).toString());
-      console.log('message', message);
+      console.log('message', message.test.title);
+      console.debug(message);
       break;
     }
     case EVENT_TEST_END: {
       console.log('EVENT_TEST_END');
       console.log(new Date(Date.now()).toString());
       console.log('message', message);
-      console.log(`EVENT_TEST_END test promise(${message.test.uniqueId}): ${startTestPromisesMap.get(message.test.uniqueId)}`);
+
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       if (sessionId) {
@@ -167,6 +171,7 @@ process.on('message', async (message) => {
       }
 
       if (message.test.status.toLowerCase() === 'pending') {
+        // it seems necessary for Cypress 9 and below
         zebrunnerApiClient.deleteTest(message.test).then(() => {
           console.log('Pending test deleted');
         });

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -29,6 +29,36 @@ const suiteTestsDurationsMap = new Map();
 const testsSessionsMap = new Map();
 const artifactsFinishPromises = [];
 
+function startTest(message) {
+  const sessionId = uuidv4();
+  testsSessionsMap.set(message.test.uniqueId, sessionId);
+
+  currentTest = message.test;
+
+  const startTestPromise = () => runStartPromise
+    .then(() => zebrunnerApiClient.startTest(message.test)
+      .then(() => {
+        zebrunnerApiClient.startTestSession(message.test, sessionId)
+          .then(() => {
+            const parsedTestLogs = message.test.body
+              .split('\n')
+              .map((el) => el.trim())
+              .filter((el) => el !== '() => {' && el !== '}' && el);
+            const testLogs = ['TEST BODY: ', ...parsedTestLogs];
+
+            return Promise.all([
+              zebrunnerApiClient.sendLogs(message.test, testLogs, 'INFO'),
+              // TODO: check and fix labeling
+              zebrunnerApiClient.sendRunLabels(),
+            ]);
+          }).catch((error) => {
+            console.log('startTestSession error: ', error);
+          });
+      }));
+
+  startTestPromisesMap.set(message.test.uniqueId, startTestPromise());
+}
+
 process.on('message', async (message) => {
   const { event } = message;
   switch (event) {
@@ -94,43 +124,19 @@ process.on('message', async (message) => {
     }
 
     case EVENT_TEST_BEGIN: {
-      const sessionId = uuidv4();
-      testsSessionsMap.set(message.test.uniqueId, sessionId);
+      startTest(message);
 
-      currentTest = message.test;
-
-      const startTest = () => runStartPromise
-        .then(() => zebrunnerApiClient.startTest(message.test)
-          .then(() => {
-            zebrunnerApiClient.startTestSession(message.test, sessionId)
-              .then(() => {
-                const parsedTestLogs = message.test.body
-                  .split('\n')
-                  .map((el) => el.trim())
-                  .filter((el) => el !== '() => {' && el !== '}' && el);
-                const testLogs = ['TEST BODY: ', ...parsedTestLogs];
-
-                return Promise.all([
-                  zebrunnerApiClient.sendLogs(message.test, testLogs, 'INFO'),
-                  // TODO: check and fix labeling
-                  zebrunnerApiClient.sendRunLabels(),
-                ]);
-              }).catch((error) => {
-                console.log('startTestSession error: ', error);
-              });
-          }));
-
-          // TODO: investigate 'Tell mocha this is a skipped test so it also shows correctly in Cypress'
-      if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
-        if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
-          // TODO: seems outdated, check and remove
-          // console.log('Start test context exchange is fired');
-          startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTest()));
-        } else {
-          // console.log('Start test is fired');
-          startTestPromisesMap.set(message.test.uniqueId, startTest());
-        }
-      }
+      // TODO: investigate 'Tell mocha this is a skipped test so it also shows correctly in Cypress'
+      // if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
+      //   if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
+      //     // TODO: seems outdated, check and remove
+      //     // console.log('Start test context exchange is fired');
+      //     startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTest()));
+      //   } else {
+      //     // console.log('Start test is fired');
+      //     startTestPromisesMap.set(message.test.uniqueId, startTest());
+      //   }
+      // }
       break;
     }
     case EVENT_TEST_PENDING: {
@@ -146,10 +152,17 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_TEST_END: {
+      console.log(`message.test.uniqueId: ${message.test.uniqueId}`); // TODO: debug log
+
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
 
       // IMPORTANT: don't delete as it is used by CyServer to stop video recording
       console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.title} ${new Date().toLocaleTimeString()}`);
+
+      if (!startTestPromisesMap.get(message.test.uniqueId)) {
+        console.log('No started test on EVENT_TEST_END!');
+        startTest(message);
+      }
 
       if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
@@ -180,6 +193,8 @@ process.on('message', async (message) => {
             currentTest = null;
           }).catch((err) => {
             console.log(`Failed to send '${message.test.status.toLowerCase()}' test data, err: `, err);
+          }).finally(() => {
+            startTestPromisesMap.delete(message.test.uniqueId);
           });
         }));
       } else {

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -158,9 +158,7 @@ process.on('message', async (message) => {
       // console.log('full heapStatistics: ', stats);
 
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
-        // Test skipped by Cypress (cypress-cucumber-preprocessor)
-        console.log(`Use case when EVENT_TEST_END comes after EVENT_SUITE_END: ${message.test.title} ${message.test.status}`);
-        // TODO: to remove above log
+        console.log(`Test skipped by Cypress (cypress-cucumber-preprocessor): ${message.test.title}`);
         break;
       }
 

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -29,36 +29,6 @@ const suiteTestsDurationsMap = new Map();
 const testsSessionsMap = new Map();
 const artifactsFinishPromises = [];
 
-function startTest(message) {
-  const sessionId = uuidv4();
-  testsSessionsMap.set(message.test.uniqueId, sessionId);
-
-  currentTest = message.test;
-
-  const startTestPromise = () => runStartPromise
-    .then(() => zebrunnerApiClient.startTest(message.test)
-      .then(() => {
-        zebrunnerApiClient.startTestSession(message.test, sessionId)
-          .then(() => {
-            const parsedTestLogs = message.test.body
-              .split('\n')
-              .map((el) => el.trim())
-              .filter((el) => el !== '() => {' && el !== '}' && el);
-            const testLogs = ['TEST BODY: ', ...parsedTestLogs];
-
-            return Promise.all([
-              zebrunnerApiClient.sendLogs(message.test, testLogs, 'INFO'),
-              // TODO: check and fix labeling
-              zebrunnerApiClient.sendRunLabels(),
-            ]);
-          }).catch((error) => {
-            console.log('startTestSession error: ', error);
-          });
-      }));
-
-  startTestPromisesMap.set(message.test.uniqueId, startTestPromise());
-}
-
 process.on('message', async (message) => {
   const { event } = message;
   switch (event) {
@@ -125,22 +95,48 @@ process.on('message', async (message) => {
 
     case EVENT_TEST_BEGIN: {
       // console.log(`EVENT_TEST_BEGIN: ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
+
       if (!startTestPromisesMap.get(message.test.uniqueId)) {
         // Use case when EVENT_TEST_BEGIN comes after EVENT_TEST_END for fast tests
-        startTest(message);
-      }
 
-      // TODO: investigate 'Tell mocha this is a skipped test so it also shows correctly in Cypress'
-      // if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
-      //   if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
-      //     // TODO: seems outdated, check and remove
-      //     // console.log('Start test context exchange is fired');
-      //     startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTest()));
-      //   } else {
-      //     // console.log('Start test is fired');
-      //     startTestPromisesMap.set(message.test.uniqueId, startTest());
-      //   }
-      // }
+        const sessionId = uuidv4();
+        testsSessionsMap.set(message.test.uniqueId, sessionId);
+
+        currentTest = message.test;
+
+        const startTestPromise = () => runStartPromise
+          .then(() => zebrunnerApiClient.startTest(message.test)
+            .then(() => {
+              zebrunnerApiClient.startTestSession(message.test, sessionId)
+                .then(() => {
+                  const parsedTestLogs = message.test.body
+                    .split('\n')
+                    .map((el) => el.trim())
+                    .filter((el) => el !== '() => {' && el !== '}' && el);
+                  const testLogs = ['TEST BODY: ', ...parsedTestLogs];
+
+                  return Promise.all([
+                    zebrunnerApiClient.sendLogs(message.test, testLogs, 'INFO'),
+                    // TODO: check and fix labeling
+                    zebrunnerApiClient.sendRunLabels(),
+                  ]);
+                }).catch((error) => {
+                  console.log('startTestSession error: ', error);
+                });
+            }));
+
+        // TODO: investigate 'Tell mocha this is a skipped test so it also shows correctly in Cypress'
+        if (!(message.test?.body?.includes('skip()') && message.test?.body?.includes('Tell mocha this is a skipped test so it also shows correctly in Cypress'))) {
+          if (process.env.REPORTING_RUN_CONTEXT && !process.env.ZEBRUNNER_RUN_ID) {
+          // TODO: seems outdated, check and remove
+          // console.log('Start test context exchange is fired');
+            startTestPromisesMap.set(message.test.uniqueId, contextExchangesPromise.then(() => startTestPromise()));
+          } else {
+          // console.log('Start test is fired');
+            startTestPromisesMap.set(message.test.uniqueId, startTestPromise());
+          }
+        }
+      }
       break;
     }
     case EVENT_TEST_PENDING: {
@@ -161,8 +157,6 @@ process.on('message', async (message) => {
         console.log(`Use case when EVENT_TEST_END comes after EVENT_SUITE_END: ${message.test.title}`);
         // TODO: to remove above log
         break;
-        // console.log('No started test on EVENT_TEST_END!');
-        // startTest(message);
       }
 
       const sessionId = testsSessionsMap.get(message.test.uniqueId);
@@ -171,7 +165,7 @@ process.on('message', async (message) => {
       console.log(`ZEBRUNNER_TEST_END ${sessionId} ${message.test.status} ${new Date().toLocaleTimeString()} ${message.test.title}`);
 
       if (message.test.status.toLowerCase() === 'pending') {
-        zebrunnerApiClient.deleteTest(message.test);
+        finishTestPromises.push(zebrunnerApiClient.deleteTest(message.test));
       } else if (startTestPromisesMap.get(message.test.uniqueId)) {
         finishTestPromises.push(startTestPromisesMap.get(message.test.uniqueId).then(async () => {
           await Promise.all(artifactsFinishPromises);

--- a/lib/process-worker.js
+++ b/lib/process-worker.js
@@ -40,7 +40,8 @@ process.on('message', async (message) => {
       break;
     }
     case EVENT_RUN_BEGIN: {
-      console.log('ZEBRUNNER_RUN_BEGIN');
+      // IMPORTANT: don't delete as it is used by CyServer to truncate video recording
+      console.log(`ZEBRUNNER_RUN_BEGIN ${uuidv4()}`);
       this.logger.info(path.basename(__filename), 'ZEBRUNNER REPORTER STARTED');
       break;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,10 +37,8 @@ const getFilesizeInBytes = (filename) => {
 const waitForFileExists = async (filePath, currentTime = 0, timeout = 10000, delay = 500) => {
   if (fs.existsSync(filePath)) return true;
 
-  if (currentTime === timeout) {
-    console.log(`No file ${filePath} yet, waiting`);
-    return false;
-  }
+  if (currentTime === timeout) return false;
+
   await new Promise((resolve) => setTimeout(() => resolve(true), delay));
 
   return waitForFileExists(filePath, currentTime + delay, timeout);
@@ -51,7 +49,6 @@ const createFile = (filePath, content) => {
     if (error) {
       console.error('An error occured while writing to the file:', error);
     }
-    console.log(`File ${filePath} has been saved`);
   });
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,17 +34,40 @@ const getFilesizeInBytes = (filename) => {
   return fileSizeInBytes;
 };
 
-const writeJsonToFile = (folderName, fileName, obj) => {
-  fs.mkdir(folderName, { recursive: true }, (err) => {
-    if (err) throw err;
-    fs.writeFile(`${folderName}/${fileName}`, JSON.stringify(obj, null, 4), 'utf8', (error) => {
-      if (error) {
-        console.log('An error occured while writing JSON Object to File.');
-        return console.log(error);
-      }
-      console.log(`JSON file ${fileName} has been saved.`);
-    });
+const waitForFileExists = async (filePath, currentTime = 0, timeout = 10000, delay = 500) => {
+  if (fs.existsSync(filePath)) return true;
+
+  if (currentTime === timeout) {
+    console.log(`No file ${filePath} yet, waiting`);
+    return false;
+  }
+  await new Promise((resolve) => setTimeout(() => resolve(true), delay));
+
+  return waitForFileExists(filePath, currentTime + delay, timeout);
+};
+
+const createFile = (filePath, content) => {
+  fs.writeFile(filePath, content, 'utf8', (error) => {
+    if (error) {
+      console.error('An error occured while writing to the file:', error);
+    }
+    console.log(`File ${filePath} has been saved`);
   });
+};
+
+const writeToFile = (folderName, fileName, content) => {
+  if (folderName && folderName !== '') {
+    fs.mkdir(folderName, { recursive: true }, (err) => {
+      if (err) throw err;
+      createFile(`${folderName}/${fileName}`, content);
+    });
+  } else {
+    createFile(fileName, content);
+  }
+};
+
+const writeJsonToFile = (folderName, fileName, obj) => {
+  writeToFile(folderName, fileName, JSON.stringify(obj, null, 4));
 };
 
 const mapJsonReplacer = (key, value) => {
@@ -95,6 +118,8 @@ module.exports = {
   getAbsolutePathByPattern,
   getFullFileNameFromPath,
   getFilesizeInBytes,
+  waitForFileExists,
+  writeToFile,
   writeJsonToFile,
   mapJsonReplacer,
   mapJsonReviver,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev8",
+  "version": "1.1.2-dev9",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev23",
+  "version": "1.1.2-dev24",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev16",
+  "version": "1.1.2-dev17",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev19",
+  "version": "1.1.2-dev20",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev13",
+  "version": "1.1.2-dev14",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev25",
+  "version": "1.1.2-dev26",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev9",
+  "version": "1.1.2-dev10",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev15",
+  "version": "1.1.2-dev16",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev6",
+  "version": "1.1.2-dev7",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev20",
+  "version": "1.1.2-dev21",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev22",
+  "version": "1.1.2-dev23",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.1",
+  "version": "1.1.2-dev4",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev28",
+  "version": "1.1.2-dev29",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev7",
+  "version": "1.1.2-dev8",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev10",
+  "version": "1.1.2-dev11",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev24",
+  "version": "1.1.2-dev25",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev21",
+  "version": "1.1.2-dev22",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev11",
+  "version": "1.1.2-dev12",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev17",
+  "version": "1.1.2-dev18",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev18",
+  "version": "1.1.2-dev19",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev5",
+  "version": "1.1.2-dev6",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev14",
+  "version": "1.1.2-dev15",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev12",
+  "version": "1.1.2-dev13",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "mocha": "^9.1.1",
     "node-ipc": "^9.1.4",
     "uuid": "^8.3.2",
+    "v8": "^0.1.0",
     "winston": "^3.7.2",
     "winston-daily-rotate-file": "^4.6.1"
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev27",
+  "version": "1.1.2-dev28",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev29",
+  "version": "1.2.0",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev4",
+  "version": "1.1.2-dev5",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "name": "@zebrunner/javascript-agent-cypress",
   "description": "Zebrunner Agent for Cypress",
-  "version": "1.1.2-dev26",
+  "version": "1.1.2-dev27",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
- fixed skipped tests for running on CyServer: added await of test finish and test delete promises on EVENT_RUN_END. When promises are resolved, save runId into file. When tests are completed, `after:run` from ZBR plugin waits for file is created for this runId.
- refactored debug messages to truncate correctly logs and video by tests